### PR TITLE
Fix spaces being copied in copied examples

### DIFF
--- a/nuxt-web/components/content/PageFunction.vue
+++ b/nuxt-web/components/content/PageFunction.vue
@@ -1,7 +1,7 @@
 <template>
   <section class="py-12 text-gray-900 dark:text-white" :id="name" ref="section">
-    <!-- Title -->
-    <div @click="copyToClipboard" class="relative flex w-fit cursor-pointer items-center gap-3" @mouseover="showCopyToClipboard = true" @mouseout="showCopyToClipboard = false">
+
+    <div @click="copyToClipboard(`${detectHost()}#${props.name.toLowerCase()}`), copied()" class="relative w-full flex w-fit cursor-pointer items-center gap-3" @mouseover="showCopyToClipboard = true" @mouseout="showCopyToClipboard = false">
       <h2 class="text-3xl font-semibold">{{ name }}</h2>
 
       <div
@@ -11,7 +11,7 @@
       </div>
 
       <div
-        class="absolute right-0 -mr-7 mt-1 flex h-6 translate-x-1/2 items-center justify-center rounded-md border border-white/5 bg-white/[3%] px-1.5 text-zinc-500 transition-all"
+        class="absolute right-0 mt-1 flex h-6 items-center justify-center rounded-md border border-white/5 bg-white/[3%] px-1.5 text-zinc-500 transition-all"
         :class="showCopied ? 'translate-y-0 opacity-100' : 'translate-y-2 opacity-0'">
         Link Copied!
       </div>
@@ -29,25 +29,14 @@
     </Callout>
 
     <!-- Function -->
+    <div class="flex justify-between text-sm dark:border-white/[8%] gap-2 mt-6 rounded-xl border border-black/5 bg-indigo-600/[2%] px-5 py-5">
     <div
-      class="mt-6 flex flex-wrap items-center gap-px rounded-xl border border-black/5 bg-indigo-600/[2%] px-5 py-5 font-mono text-sm text-gray-900 dark:border-white/[8%] dark:bg-white/[3%] dark:text-gray-400">
-      {{ name }}
+      class=" font-mono text-gray-900 dark:text-gray-400">
+      <span>{{ name }}</span>
       <span class="mr-px text-gray-500">(</span>
-
-      <div class="flex items-center gap-1 rounded-md bg-indigo-600/[5%] px-1 py-px text-indigo-600 dark:bg-white/[8%] text-pretty dark:text-indigo-100">
-        {{ params }}
-      </div>
-
-      <!-- <template v-for="(param, index) in paramsObject" :key="index">
-        <div class="flex h-5 items-center gap-1 rounded-md bg-indigo-600/[5%] px-1 py-px text-indigo-600 dark:bg-white/[8%] dark:text-indigo-100">
-          <span v-if="param.key">{{ param.key }}</span>
-          <span v-if="param.value">{{ param.value }}</span>
-          <span v-if="param.defaultValue">={{ param.defaultValue }}</span>
-        </div>
-
-        <span v-if="index < paramsObject.length - 1" class="mr-0.5">,</span>
-      </template> -->
+      <span class="inline-flex items-center gap-1 rounded-md bg-indigo-600/[5%] px-1 py-px text-indigo-600 dark:bg-white/[8%] text-pretty dark:text-indigo-100">{{ params }}</span>
       <span class="ml-px text-gray-500">)</span>
+      </div>
     </div>
   </section>
 </template>
@@ -77,7 +66,8 @@
   const showCopyToClipboard = ref(false)
   const showCopied = ref(false)
   const section = ref<HTMLElement>()
-  const activeSections = useState('activeSections', () => [])
+const activeSections = useState('activeSections', () => [])
+  
 
   const sectionIsVisible = useElementVisibility(section)
 
@@ -86,32 +76,6 @@
     setTimeout(() => {
       showCopied.value = false
     }, 800)
-  }
-
-  // const paramPattern = /\s*([^:]+?)\s*:\s*([^=]+?)\s*(?:=\s*([^,]+))?\s*(?=,|$)/g
-  // const matches = props.params?.matchAll(paramPattern) || []
-
-  // const paramsObject = computed(() => {
-  //   const matchesArray = Array.from(matches)
-  //   return matchesArray.map((match) => {
-  //     const key = match[1]
-  //     const value = match[2]
-  //     const defaultValue = match[3]
-  //     return {
-  //       key,
-  //       value,
-  //       defaultValue
-  //     }
-  //   })
-  // })
-
-  function copyToClipboard() {
-    const url = window.location.href
-    const hash = `#${props.name.toLowerCase()}`
-    const text = `${url}${hash}`
-    navigator.clipboard.writeText(text)
-    copied()
-    showCopyToClipboard.value = false
   }
 
   watch(

--- a/nuxt-web/components/content/PageFunction.vue
+++ b/nuxt-web/components/content/PageFunction.vue
@@ -32,9 +32,9 @@
     <div class="flex justify-between text-sm dark:border-white/[8%] gap-2 mt-6 rounded-xl border border-black/5 bg-indigo-600/[2%] px-5 py-5">
     <div
       class=" font-mono text-gray-900 dark:text-gray-400">
-      <span>{{ name }}</span>
+      <span class="text-indigo-600 dark:text-gray-200">{{ name }}</span>
       <span class="mr-px text-gray-500">(</span>
-      <span class="inline-flex items-center gap-1 rounded-md bg-indigo-600/[5%] px-1 py-px text-indigo-600 dark:bg-white/[8%] text-pretty dark:text-indigo-100">{{ params }}</span>
+      <span class="text-indigo-600 dark:text-gray-200">{{ params }}</span>
       <span class="ml-px text-gray-500">)</span>
       </div>
     </div>
@@ -66,9 +66,7 @@
   const showCopyToClipboard = ref(false)
   const showCopied = ref(false)
   const section = ref<HTMLElement>()
-const activeSections = useState('activeSections', () => [])
-  
-
+  const activeSections = useState('activeSections', () => [])
   const sectionIsVisible = useElementVisibility(section)
 
   function copied() {

--- a/nuxt-web/components/example/Code.vue
+++ b/nuxt-web/components/example/Code.vue
@@ -6,7 +6,15 @@
             </div>
             <div class="min-h-7 text-lg font-medium text-gray-500 dark:text-white/50 text-pretty" v-html="formattedCode"></div>
         </div>
-        <div class="font-mono text-sm/none text-gray-300 max-md:hidden dark:text-white/25">Example</div>
+        <button type="button" @click="copyToClipboard(props.code), copied()" class="flex items-center gap-2 text-indigo-500 dark:text-white/50 hover:text-indigo-600 dark:hover:text-white/75">
+            <Icon v-if="showCopied" name="🎉" class="w-4 h-4" />
+            <Icon v-else name="heroicons:clipboard" class="w-3 h-3" />
+            <span class="text-sm/none">
+                <span v-if="showCopied">Copied</span>
+                <span v-else>Copy</span>
+            </span>
+        </button>
+        
     </div>
 </template>
 
@@ -16,6 +24,14 @@ const props = defineProps<{
 }>();
 
 const formattedCode = computed(() => formatCode(props.code));
+const showCopied = ref(false)
+
+function copied() {
+    showCopied.value = true
+    setTimeout(() => {
+        showCopied.value = false
+    }, 800)
+}
 
 function formatCode(input: string) {
   const regex = /(\b\d+(\.\d+)?\b|(\b\w+\b):\s*'[^']*'|\b\w+\b:\s*\b[\w.-]+\b)/g;


### PR DESCRIPTION
Fixes spaces in copied example codes
Adds copyToClipboard to interactive examples as well