### PR TITLE
Ensures 0 decimals are removed

### DIFF
--- a/src/formatters.test.ts
+++ b/src/formatters.test.ts
@@ -48,6 +48,7 @@ test('formatDurationLabels', () => {
   expect(mod.formatDurationLabels(3600 * 2 + 60 + 1.5)).toBe('2 hours 1 minute 1 second 500 milliseconds')
   expect(mod.formatDurationLabels(3600 * 400 + 60 + 1)).toBe('16 days 16 hours 1 minute 1 second')
   expect(mod.formatDurationLabels(3600 * 400 + 60 + 1, { round: true })).toBe('16.7 days')
+  expect(mod.formatDurationLabels(9241233, { round: true })).toBe('107 days')
 })
 
 test('formatDurationNumbers', () => {

--- a/src/formatters.ts
+++ b/src/formatters.ts
@@ -151,12 +151,12 @@ export function formatDurationLabels(
   ]
 
   if (options?.round) {
-    // Find the largest unit that has a value
     for (const { unit, value } of units) {
       if (seconds >= value) {
         const unitValue = seconds / value
         const hasDecimal = unitValue % 1 !== 0
-        return formatUnit(unitValue, { unit, decimals: hasDecimal ? 1 : 0, unitDisplay: options?.labels ?? 'long' })
+        const decimals = hasDecimal && unitValue.toFixed(1).endsWith('.0') ? 0 : hasDecimal ? 1 : 0
+        return formatUnit(unitValue, { unit, decimals, unitDisplay: options?.labels ?? 'long' })
       }
     }
   }


### PR DESCRIPTION
This pull request includes updates to the `formatDurationLabels` function and its corresponding test cases to improve the accuracy of duration formatting.

### Improvements to duration formatting:

* [`src/formatters.ts`](diffhunk://#diff-153e418f4f60c652aa1daef553191aeab805a9da6cd7aaa3577aa98a0dcec2abL154-R159): Modified the `formatDurationLabels` function to handle cases where the rounded value ends with '.0' by setting the decimals to 0. This ensures that the formatted output does not include unnecessary decimal points.

### Updates to test cases:

* [`src/formatters.test.ts`](diffhunk://#diff-8555c4c299fc819451495c8819c4a7a656b79ff8e3fe9be80aac4cfda3471a88R51): Added a new test case to verify the correct formatting of a large duration value when rounding is enabled. This helps ensure that the updated logic in `formatDurationLabels` works as expected.